### PR TITLE
Fix typo in fal endpoint description

### DIFF
--- a/src/lib/fal.ts
+++ b/src/lib/fal.ts
@@ -50,7 +50,7 @@ export const AVAILABLE_ENDPOINTS: ApiInfo[] = [
   {
     endpointId: "fal-ai/imagen4/preview",
     label: "Google Imagen 4",
-    description: "Generate a images from a text prompt",
+    description: "Generate images from a text prompt",
     cost: "",
     category: "image",
   },


### PR DESCRIPTION
## Summary
- fix a typo in the description for the Google Imagen 4 endpoint

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684074bc6114832fbc79f02f79030d84