### PR TITLE
Fix keyboard shortcuts interfering with forms

### DIFF
--- a/src/hooks/use-professional-shortcuts.ts
+++ b/src/hooks/use-professional-shortcuts.ts
@@ -59,6 +59,18 @@ export function useProfessionalShortcuts(handlers: ProfessionalShortcutsProps) {
       const { key, ctrlKey, metaKey, shiftKey, altKey } = event;
       const isCmd = ctrlKey || metaKey;
 
+      // Ignore shortcuts when a form element or contenteditable element is active
+      const active = document.activeElement as HTMLElement | null;
+      if (
+        active &&
+        (active.tagName === "INPUT" ||
+          active.tagName === "TEXTAREA" ||
+          active.tagName === "SELECT" ||
+          active.isContentEditable)
+      ) {
+        return;
+      }
+
       // Prevent default for handled shortcuts
       const preventDefault = () => {
         event.preventDefault();


### PR DESCRIPTION
## Summary
- ignore global keyboard shortcuts when typing in input, textarea, select or contenteditable elements

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run format` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_684079360900832fb657c4ceefb0885f