### PR TITLE
Remove 30s keyframe restriction

### DIFF
--- a/src/components/enhanced-timeline.tsx
+++ b/src/components/enhanced-timeline.tsx
@@ -135,7 +135,7 @@ export default function EnhancedTimeline() {
       }
     });
 
-    return Math.min(Math.max(maxDuration, 5), 30); // Min 5 seconds, max 30 seconds
+    return Math.max(maxDuration, 5);
   }, [allKeyframes]);
 
   // Add new track mutation
@@ -216,7 +216,7 @@ export default function EnhancedTimeline() {
     await db.keyFrames.create({
       trackId: targetTrack.id,
       timestamp: playerCurrentTimestamp * 1000,
-      duration: Math.min(duration, 30000),
+      duration,
       data: {
         type:
           media.mediaType === "image"

--- a/src/components/professional-timeline.tsx
+++ b/src/components/professional-timeline.tsx
@@ -213,7 +213,7 @@ export default function ProfessionalTimeline() {
       }
     });
 
-    return Math.min(Math.max(maxDuration, 5), 30); // Min 5 seconds, max 30 seconds
+    return Math.max(maxDuration, 5);
   }, [allKeyframes]);
 
   // Add new track mutation
@@ -425,7 +425,7 @@ export default function ProfessionalTimeline() {
     await db.keyFrames.create({
       trackId: targetTrack.id,
       timestamp: playerCurrentTimestamp * 1000,
-      duration: Math.min(duration, 30000),
+      duration,
       data: {
         type:
           media.mediaType === "image"

--- a/src/components/video/track.tsx
+++ b/src/components/video/track.tsx
@@ -346,7 +346,7 @@ export function VideoTrackView({
         let newWidth = startWidth + deltaX;
         const minDuration = 1000;
         const mediaDuration = resolveDuration(media) ?? 5000;
-        const maxDuration = Math.min(mediaDuration, 30000);
+        const maxDuration = mediaDuration;
 
         const timelineElement = trackElement.closest(".timeline-container");
         const parentWidth = timelineElement


### PR DESCRIPTION
## Summary
- allow clips longer than 30s across timelines
- remove old limit button from timeline bar
- set maxDuration to actual media duration

## Testing
- `npx biome format --write`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68407d065938832f84ed9797825e3bde