### PR TITLE
Allow timeline to exceed 30 seconds

### DIFF
--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -27,7 +27,6 @@ export default function BottomBar() {
   const formattedTimestamp =
     (playerCurrentTimestamp < 10 ? "0" : "") +
     playerCurrentTimestamp.toFixed(2);
-  const minTrackWidth = `${((2 / 30) * 100).toFixed(2)}%`;
   const [dragOverTracks, setDragOverTracks] = useState(false);
 
   // Professional timeline state
@@ -126,8 +125,13 @@ export default function BottomBar() {
       }
     });
 
-    return Math.min(Math.max(maxDuration, 5), 30); // Min 5 seconds, max 30 seconds
+    return Math.max(maxDuration, 5);
   }, [allKeyframes]);
+
+  const minTrackWidth = useMemo(
+    () => `${((2 / totalDuration) * 100).toFixed(2)}%`,
+    [totalDuration],
+  );
 
   // Timeline handlers
   const handleClipSelect = (clipId: string, multiSelect: boolean) => {
@@ -509,10 +513,10 @@ export default function BottomBar() {
           <div
             className="absolute z-[32] top-6 bottom-0 w-[2px] bg-white/30 ms-4"
             style={{
-              left: `${((playerCurrentTimestamp / 30) * 100).toFixed(2)}%`,
+              left: `${((playerCurrentTimestamp / totalDuration) * 100).toFixed(2)}%`,
             }}
           />
-          <TimelineRuler className="z-30 pointer-events-none" />
+          <TimelineRuler duration={totalDuration} className="z-30 pointer-events-none" />
           <div className="flex timeline-container flex-col h-full mx-4 mt-10 gap-2 z-[31] pb-2">
             {Object.values(trackObj).map((track, index) =>
               track ? (
@@ -527,6 +531,7 @@ export default function BottomBar() {
                   onClipCut={handleClipCut}
                   onClipDrag={handleClipDrag}
                   onClipResize={handleClipResize}
+                  totalDuration={totalDuration}
                   style={{
                     minWidth: minTrackWidth,
                   }}

--- a/src/components/enhanced-clip.tsx
+++ b/src/components/enhanced-clip.tsx
@@ -15,12 +15,14 @@ interface EnhancedClipProps {
   frame: VideoKeyFrame;
   track: VideoTrack;
   timelineState: any;
+  totalDuration: number;
 }
 
 export function EnhancedClip({
   frame,
   track,
   timelineState,
+  totalDuration,
 }: EnhancedClipProps) {
   const queryClient = useQueryClient();
   const projectId = useProjectId();
@@ -76,8 +78,8 @@ export function EnhancedClip({
   };
 
   // Calculate clip position and size
-  const clipLeft = (frame.timestamp / 1000 / 30) * 100; // Convert to percentage
-  const clipWidth = (frame.duration / 1000 / 30) * 100; // Convert to percentage
+  const clipLeft = (frame.timestamp / 1000 / totalDuration) * 100; // Convert to percentage
+  const clipWidth = (frame.duration / 1000 / totalDuration) * 100; // Convert to percentage
 
   const coverImage =
     media?.mediaType === "video"

--- a/src/components/enhanced-timeline.tsx
+++ b/src/components/enhanced-timeline.tsx
@@ -54,7 +54,6 @@ export default function EnhancedTimeline() {
   const formattedTimestamp =
     (playerCurrentTimestamp < 10 ? "0" : "") +
     playerCurrentTimestamp.toFixed(2);
-  const minTrackWidth = `${((2 / 30) * 100).toFixed(2)}%`;
   const [dragOverTracks, setDragOverTracks] = useState(false);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
     new Set(),
@@ -135,8 +134,13 @@ export default function EnhancedTimeline() {
       }
     });
 
-    return Math.min(Math.max(maxDuration, 5), 30); // Min 5 seconds, max 30 seconds
+    return Math.max(maxDuration, 5);
   }, [allKeyframes]);
+
+  const minTrackWidth = useMemo(
+    () => `${((2 / totalDuration) * 100).toFixed(2)}%`,
+    [totalDuration],
+  );
 
   // Add new track mutation
   const addTrackMutation = useMutation({
@@ -341,12 +345,15 @@ export default function EnhancedTimeline() {
           <div
             className="absolute z-[32] top-0 bottom-0 w-[2px] bg-red-500 pointer-events-none"
             style={{
-              left: `${((playerCurrentTimestamp / 30) * 100).toFixed(2)}%`,
+              left: `${((playerCurrentTimestamp / totalDuration) * 100).toFixed(2)}%`,
             }}
           />
 
           {/* Timeline Ruler */}
-          <TimelineRuler className="z-30 pointer-events-none h-8 border-b border-border" />
+          <TimelineRuler
+            duration={totalDuration}
+            className="z-30 pointer-events-none h-8 border-b border-border"
+          />
 
           {/* Track Rows */}
           <div className="flex flex-col">
@@ -363,6 +370,7 @@ export default function EnhancedTimeline() {
                       track={track}
                       timelineState={timelineState}
                       minTrackWidth={minTrackWidth}
+                      totalDuration={totalDuration}
                     />
                   ))}
               </div>

--- a/src/components/enhanced-track-row.tsx
+++ b/src/components/enhanced-track-row.tsx
@@ -10,12 +10,14 @@ interface EnhancedTrackRowProps {
   track: VideoTrack;
   timelineState: any;
   minTrackWidth: string;
+  totalDuration: number;
 }
 
 export function EnhancedTrackRow({
   track,
   timelineState,
   minTrackWidth,
+  totalDuration,
 }: EnhancedTrackRowProps) {
   const queryClient = useQueryClient();
   const [isDragOver, setIsDragOver] = useState(false);
@@ -52,7 +54,7 @@ export function EnhancedTrackRow({
       const rect = e.currentTarget.getBoundingClientRect();
       const x = e.clientX - rect.left;
       const timelineWidth = rect.width;
-      const timestamp = (x / timelineWidth) * 30 * 1000; // 30 seconds max
+      const timestamp = (x / timelineWidth) * totalDuration * 1000;
 
       // Create keyframe at drop position
       await db.keyFrames.create({
@@ -96,11 +98,11 @@ export function EnhancedTrackRow({
     >
       {/* Track Background Grid */}
       <div className="absolute inset-0 opacity-10">
-        {Array.from({ length: 30 }).map((_, i) => (
+        {Array.from({ length: Math.ceil(totalDuration) }).map((_, i) => (
           <div
             key={i}
             className="absolute top-0 bottom-0 w-px bg-border"
-            style={{ left: `${(i / 30) * 100}%` }}
+            style={{ left: `${(i / Math.ceil(totalDuration)) * 100}%` }}
           />
         ))}
       </div>
@@ -112,6 +114,7 @@ export function EnhancedTrackRow({
           frame={frame}
           track={track}
           timelineState={timelineState}
+          totalDuration={totalDuration}
         />
       ))}
 

--- a/src/components/professional-timeline.tsx
+++ b/src/components/professional-timeline.tsx
@@ -213,7 +213,7 @@ export default function ProfessionalTimeline() {
       }
     });
 
-    return Math.min(Math.max(maxDuration, 5), 30); // Min 5 seconds, max 30 seconds
+    return Math.max(maxDuration, 5);
   }, [allKeyframes]);
 
   // Add new track mutation
@@ -703,7 +703,10 @@ export default function ProfessionalTimeline() {
 
           {/* Timeline Ruler */}
           <div className="h-8 border-b border-border bg-muted/50 relative">
-            <TimelineRuler className="z-30 pointer-events-none h-full" />
+            <TimelineRuler
+              duration={totalDuration}
+              className="z-30 pointer-events-none h-full"
+            />
           </div>
 
           {/* Track Rows */}

--- a/src/components/professional-track-row.tsx
+++ b/src/components/professional-track-row.tsx
@@ -189,13 +189,13 @@ export function ProfessionalTrackRow({
 
   // Generate grid lines for visual reference
   const gridLines = [];
-  const gridInterval = totalDuration / 30; // 30 grid lines
-  for (let i = 0; i <= 30; i++) {
+  const gridCount = Math.ceil(totalDuration);
+  for (let i = 0; i <= gridCount; i++) {
     gridLines.push(
       <div
         key={i}
         className="absolute top-0 bottom-0 w-px bg-border opacity-20"
-        style={{ left: `${(i / 30) * 100}%` }}
+        style={{ left: `${(i / gridCount) * 100}%` }}
       />,
     );
   }

--- a/src/components/video/track.tsx
+++ b/src/components/video/track.tsx
@@ -86,6 +86,7 @@ export function VideoTrackRow({
           onClipCut={onClipCut}
           onClipDrag={onClipDrag}
           onClipResize={onClipResize}
+          totalDuration={totalDuration}
         />
       ))}
     </div>
@@ -179,6 +180,7 @@ type VideoTrackViewProps = {
     handle: "left" | "right",
     deltaX: number,
   ) => void;
+  totalDuration: number;
 } & HTMLAttributes<HTMLDivElement>;
 
 export function VideoTrackView({
@@ -190,6 +192,7 @@ export function VideoTrackView({
   onClipCut,
   onClipDrag,
   onClipResize,
+  totalDuration,
   ...props
 }: VideoTrackViewProps) {
   const queryClient = useQueryClient();

--- a/src/components/video/track.tsx
+++ b/src/components/video/track.tsx
@@ -39,6 +39,7 @@ type VideoTrackRowProps = {
     handle: "left" | "right",
     deltaX: number,
   ) => void;
+  totalDuration: number;
 } & HTMLAttributes<HTMLDivElement>;
 
 export function VideoTrackRow({
@@ -48,6 +49,7 @@ export function VideoTrackRow({
   onClipCut,
   onClipDrag,
   onClipResize,
+  totalDuration,
   ...props
 }: VideoTrackRowProps) {
   const { data: keyframes = [] } = useQuery({
@@ -74,8 +76,8 @@ export function VideoTrackRow({
           key={frame.id}
           className="absolute top-0 bottom-0"
           style={{
-            left: `${(frame.timestamp / 10 / 30).toFixed(2)}%`,
-            width: `${(frame.duration / 10 / 30).toFixed(2)}%`,
+            left: `${((frame.timestamp / 1000) / totalDuration) * 100}%`,
+            width: `${((frame.duration / 1000) / totalDuration) * 100}%`,
           }}
           track={data}
           frame={frame}
@@ -304,10 +306,10 @@ export function VideoTrackView({
       const parentWidth = timelineElement
         ? (timelineElement as HTMLElement).offsetWidth
         : 1;
-      const newTimestamp = (newLeft / parentWidth) * 30;
+      const newTimestamp = (newLeft / parentWidth) * totalDuration;
       frame.timestamp = (newTimestamp < 0 ? 0 : newTimestamp) * 1000;
 
-      trackElement.style.left = `${((frame.timestamp / 30) * 100) / 1000}%`;
+      trackElement.style.left = `${((frame.timestamp / 1000) / totalDuration) * 100}%`;
       db.keyFrames.update(frame.id, { timestamp: frame.timestamp });
     };
 
@@ -352,18 +354,18 @@ export function VideoTrackView({
         const parentWidth = timelineElement
           ? (timelineElement as HTMLElement).offsetWidth
           : 1;
-        let newDuration = (newWidth / parentWidth) * 30 * 1000;
+        let newDuration = (newWidth / parentWidth) * totalDuration * 1000;
 
         if (newDuration < minDuration) {
-          newWidth = (minDuration / 1000 / 30) * parentWidth;
+          newWidth = (minDuration / 1000 / totalDuration) * parentWidth;
           newDuration = minDuration;
         } else if (newDuration > maxDuration) {
-          newWidth = (maxDuration / 1000 / 30) * parentWidth;
+          newWidth = (maxDuration / 1000 / totalDuration) * parentWidth;
           newDuration = maxDuration;
         }
 
         frame.duration = newDuration;
-        trackElement.style.width = `${((frame.duration / 30) * 100) / 1000}%`;
+        trackElement.style.width = `${((frame.duration / 1000) / totalDuration) * 100}%`;
       } else {
         // Left handle: adjust timestamp and duration (trim in-point)
         let newLeft = startLeft + deltaX;
@@ -373,7 +375,7 @@ export function VideoTrackView({
           : 1;
 
         // Calculate new timestamp
-        const newTimestamp = Math.max(0, (newLeft / parentWidth) * 30 * 1000);
+        const newTimestamp = Math.max(0, (newLeft / parentWidth) * totalDuration * 1000);
         const timestampDelta = newTimestamp - startTimestamp;
 
         // Adjust duration to maintain end point
@@ -382,8 +384,8 @@ export function VideoTrackView({
         frame.timestamp = newTimestamp;
         frame.duration = newDuration;
 
-        trackElement.style.left = `${((frame.timestamp / 30) * 100) / 1000}%`;
-        trackElement.style.width = `${((frame.duration / 30) * 100) / 1000}%`;
+        trackElement.style.left = `${((frame.timestamp / 1000) / totalDuration) * 100}%`;
+        trackElement.style.width = `${((frame.duration / 1000) / totalDuration) * 100}%`;
       }
 
       // Call custom resize handler if provided
@@ -397,8 +399,8 @@ export function VideoTrackView({
       frame.duration = Math.round(frame.duration / 100) * 100;
       frame.timestamp = Math.round(frame.timestamp / 100) * 100;
 
-      trackElement.style.left = `${((frame.timestamp / 30) * 100) / 1000}%`;
-      trackElement.style.width = `${((frame.duration / 30) * 100) / 1000}%`;
+      trackElement.style.left = `${((frame.timestamp / 1000) / totalDuration) * 100}%`;
+      trackElement.style.width = `${((frame.duration / 1000) / totalDuration) * 100}%`;
 
       db.keyFrames.update(frame.id, {
         duration: frame.duration,


### PR DESCRIPTION
## Summary
- lift 30s cap on totalDuration across timeline components
- scale playhead and grid calculations by computed duration
- pass duration to `TimelineRuler`
- update track components to position clips relative to totalDuration

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407d0364f0832f98a8a4d4b419c9d2