### PR TITLE
Invalidate all keyframes query on clip changes

### DIFF
--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -53,7 +53,7 @@ export default function BottomBar() {
 
   // Get all keyframes for duration calculation
   const { data: allKeyframes = [] } = useQuery({
-    queryKey: ["all-keyframes", projectId],
+    queryKey: queryKeys.allKeyframes(projectId),
     queryFn: async () => {
       const allFrames: any[] = [];
       for (const track of tracks) {

--- a/src/components/enhanced-timeline.tsx
+++ b/src/components/enhanced-timeline.tsx
@@ -80,7 +80,7 @@ export default function EnhancedTimeline() {
 
   // Get all keyframes for duration calculation
   const { data: allKeyframes = [] } = useQuery({
-    queryKey: ["all-keyframes", projectId],
+    queryKey: queryKeys.allKeyframes(projectId),
     queryFn: async () => {
       const allFrames: any[] = [];
       for (const track of tracks) {

--- a/src/components/professional-timeline.tsx
+++ b/src/components/professional-timeline.tsx
@@ -121,7 +121,7 @@ export default function ProfessionalTimeline() {
 
   // Get all keyframes for duration calculation
   const { data: allKeyframes = [] } = useQuery({
-    queryKey: ["all-keyframes", projectId],
+    queryKey: queryKeys.allKeyframes(projectId),
     queryFn: async () => {
       const allFrames: any[] = [];
       for (const track of tracks) {

--- a/src/data/queries.ts
+++ b/src/data/queries.ts
@@ -22,6 +22,7 @@ export const queryKeys = {
   ],
   projectTracks: (projectId: string) => ["tracks", projectId],
   projectPreview: (projectId: string) => ["preview", projectId],
+  allKeyframes: (projectId: string) => ["all-keyframes", projectId],
 };
 
 export const refreshVideoCache = async (
@@ -34,6 +35,9 @@ export const refreshVideoCache = async (
     }),
     queryClient.invalidateQueries({
       queryKey: queryKeys.projectPreview(projectId),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.allKeyframes(projectId),
     }),
     queryClient.invalidateQueries({
       queryKey: ["frames"],


### PR DESCRIPTION
## Summary
- add a dedicated `allKeyframes` query key
- reference the key in timeline queries
- invalidate the new key when refreshing video cache

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b1ca6714832fac1f79091c85a82e