### PR TITLE
Implement generation completion callback

### DIFF
--- a/src/components/media-gallery.tsx
+++ b/src/components/media-gallery.tsx
@@ -130,7 +130,6 @@ export function MediaGallerySheet({
   const setGenerateMediaType = useVideoProjectStore(
     (s) => s.setGenerateMediaType,
   );
-  const onGenerate = useVideoProjectStore((s) => s.onGenerate);
 
   const handleUpscaleDialog = () => {
     setGenerateMediaType("video");
@@ -171,7 +170,7 @@ export function MediaGallerySheet({
     setEndpointId(selectedMedia.endpointId as string);
     setGenerateData(selectedMedia.input || {});
     setSelectedMediaId(null);
-    onGenerate();
+    openGenerateDialog();
   };
 
   // Event handlers

--- a/src/components/right-panel.tsx
+++ b/src/components/right-panel.tsx
@@ -275,6 +275,7 @@ export default function RightPanel({
       onSuccess: async () => {
         if (!createJob.isError) {
           handleOnOpenChange(false);
+          videoProjectStore.onGenerate();
         }
       },
       onError: (error) => {
@@ -286,10 +287,6 @@ export default function RightPanel({
       },
     });
   };
-
-  useEffect(() => {
-    videoProjectStore.onGenerate = handleOnGenerate;
-  }, [handleOnGenerate]);
 
   const handleSelectMedia = (media: MediaItem) => {
     const asset = endpoint?.inputAsset?.find((item) => {

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -33,6 +33,11 @@ interface VideoProjectProps {
   generateData: GenerateData;
   exportDialogOpen: boolean;
   endpointId: string;
+  /**
+   * Counter used to emit generation events. Components can subscribe to this
+   * value to react when a new job has been created.
+   */
+  generationCount: number;
 }
 
 interface VideoProjectState extends VideoProjectProps {
@@ -73,6 +78,7 @@ const DEFAULT_PROPS: VideoProjectProps = {
     audio_url: null,
   },
   exportDialogOpen: false,
+  generationCount: 0,
 };
 
 type VideoProjectStore = ReturnType<typeof createVideoProjectStore>;
@@ -104,8 +110,8 @@ export const createVideoProjectStore = (
           voice: "",
         },
       }),
-    // [NOTE]: This is a placeholder function
-    onGenerate: () => {},
+    onGenerate: () =>
+      set((s) => ({ generationCount: s.generationCount + 1 })),
     setPlayer: (player: PlayerRef) => set({ player }),
     setPlayerCurrentTimestamp: (playerCurrentTimestamp: number) =>
       set({ playerCurrentTimestamp }),


### PR DESCRIPTION
## Summary
- add `generationCount` to video project state
- update `onGenerate` to emit an event
- call the event from `RightPanel` after creating a job
- open generation dialog for media variations

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run format` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_684228e3a388832fbbeb4f1c122fed6b